### PR TITLE
22175 senders implementors doesnt properly use the ast and cursor location

### DIFF
--- a/src/AST-Core/RBAbstractBlockVisitor.class.st
+++ b/src/AST-Core/RBAbstractBlockVisitor.class.st
@@ -1,0 +1,57 @@
+"
+Abstract visitor providing generic block visiting capabilities.
+Subclasses provide specific node type capabilties
+
+"
+Class {
+	#name : #RBAbstractBlockVisitor,
+	#superclass : #RBProgramNodeVisitor,
+	#instVars : [
+		'visitBlock'
+	],
+	#category : #'AST-Core-Visitors'
+}
+
+{ #category : #enumerating }
+RBAbstractBlockVisitor class >> visit: aTree detect: aBlock [
+	
+	^self visit: aTree detect: aBlock ifNone: [ NotFound signalFor: aBlock ]
+]
+
+{ #category : #enumerating }
+RBAbstractBlockVisitor class >> visit: aTree detect: aBlock ifNone: anErrorBlock [
+	| result |
+	
+	result := OrderedCollection new.
+	
+	self visit: aTree do: [ :node |
+		(aBlock value: node) ifTrue: [ ^node ] ].
+	
+	^anErrorBlock value
+]
+
+{ #category : #enumerating }
+RBAbstractBlockVisitor class >> visit: aTree do: aBlock [
+	^self new 
+		visitBlock: aBlock;
+		visitNode: aTree
+]
+
+{ #category : #enumerating }
+RBAbstractBlockVisitor class >> visit: aTree select: aBlock [
+	| result |
+	result := OrderedCollection new.
+	self visit: aTree do: [ :node |
+		(aBlock value: node) ifTrue: [ result add: node ] ].
+	^result
+]
+
+{ #category : #accessing }
+RBAbstractBlockVisitor >> visitBlock [
+	^ visitBlock
+]
+
+{ #category : #accessing }
+RBAbstractBlockVisitor >> visitBlock: anObject [
+	visitBlock := anObject
+]

--- a/src/AST-Core/RBComment.class.st
+++ b/src/AST-Core/RBComment.class.st
@@ -46,7 +46,7 @@ RBComment >> contents [
 	^ contents
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #testing }
 RBComment >> intersectsInterval: anInterval [ 
 	"Make comments polymorphic with program nodes for hit detection"
 	^(anInterval first between: self start and: self stop) 

--- a/src/AST-Core/RBComment.class.st
+++ b/src/AST-Core/RBComment.class.st
@@ -46,6 +46,13 @@ RBComment >> contents [
 	^ contents
 ]
 
+{ #category : #'initialize-release' }
+RBComment >> intersectsInterval: anInterval [ 
+	"Make comments polymorphic with program nodes for hit detection"
+	^(anInterval first between: self start and: self stop) 
+		or: [self start between: anInterval first and: anInterval last]
+]
+
 { #category : #printing }
 RBComment >> printOn: aStream [
 	super printOn: aStream.

--- a/src/AST-Core/RBCommentNodeVisitor.class.st
+++ b/src/AST-Core/RBCommentNodeVisitor.class.st
@@ -13,8 +13,9 @@ Class {
 
 { #category : #accessing }
 RBCommentNodeVisitor >> visitNode: aNode [
-	aNode comments ifNotEmpty: [ :value |
-		self visitBlock cull: value cull: aNode ].
+	aNode comments ifNotEmpty: [ :commentNodes |
+		commentNodes do: [ :commentNode |
+			self visitBlock cull: commentNode cull: aNode ] ].
 	
 	super visitNode: aNode
 ]

--- a/src/AST-Core/RBCommentNodeVisitor.class.st
+++ b/src/AST-Core/RBCommentNodeVisitor.class.st
@@ -1,0 +1,20 @@
+"
+Visit any RBCommentNode in the syntax tree and evaluate a generic block.
+
+The block  has two optional parameters:  
+	aCommentArray (the collection of 1 or more RBComment's)
+	aNode (the node which containts the comment)
+"
+Class {
+	#name : #RBCommentNodeVisitor,
+	#superclass : #RBAbstractBlockVisitor,
+	#category : #'AST-Core-Visitors'
+}
+
+{ #category : #accessing }
+RBCommentNodeVisitor >> visitNode: aNode [
+	aNode comments ifNotEmpty: [ :value |
+		self visitBlock cull: value cull: aNode ].
+	
+	super visitNode: aNode
+]

--- a/src/AST-Core/RBGenericNodeVisitor.class.st
+++ b/src/AST-Core/RBGenericNodeVisitor.class.st
@@ -1,0 +1,14 @@
+"
+Visit any RBProgrmNode in the syntax tree and evaluate a generic block
+"
+Class {
+	#name : #RBGenericNodeVisitor,
+	#superclass : #RBAbstractBlockVisitor,
+	#category : #'AST-Core-Visitors'
+}
+
+{ #category : #accessing }
+RBGenericNodeVisitor >> visitNode: aNode [
+	super visitNode: aNode.
+	self visitBlock value: aNode
+]

--- a/src/AST-Core/RBParseErrorNodeVisitor.class.st
+++ b/src/AST-Core/RBParseErrorNodeVisitor.class.st
@@ -1,0 +1,13 @@
+"
+Visit any RBParseErrorNode in the syntax tree and evaluate a generic block
+"
+Class {
+	#name : #RBParseErrorNodeVisitor,
+	#superclass : #RBAbstractBlockVisitor,
+	#category : #'AST-Core-Visitors'
+}
+
+{ #category : #accessing }
+RBParseErrorNodeVisitor >> visitParseErrorNode: aNode [
+	self visitBlock value: aNode
+]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -178,6 +178,11 @@ RBParser >> cascadeNodeClass [
 	^ RBCascadeNode
 ]
 
+{ #category : #accessing }
+RBParser >> currentToken [
+	^currentToken 
+]
+
 { #category : #'error handling' }
 RBParser >> errorBlock [
 	^errorBlock ifNil: [[:message :position | ]] ifNotNil: [errorBlock]
@@ -913,7 +918,7 @@ RBParser >> parseVariableNode [
 
 { #category : #'error handling' }
 RBParser >> parserError: aString [ 
-	"Let the errorBlock try to recover from the error."
+	"Let the errorBlock try to recover from the error. Answer a ParseNode (possibly an RBParseErrorNode) or signal there is new source"
 	| errorNode errorMessage errorPosition newSource |
 	errorNode := self errorBlock cull: aString cull: self errorPosition cull: self.
 	errorNode ifNotNil: [ ^ errorNode ].
@@ -929,7 +934,7 @@ RBParser >> parserError: aString [
 						location: errorPosition.
 	
 	"If the syntax error notification is resumed, then the source was corrected and we have to announce that parsing can restart."					
-	ReparseAfterSourceEditing signalWithNewSource: newSource
+	ReparseAfterSourceEditing signalWithNewSource: newSource.
 ]
 
 { #category : #private }

--- a/src/AST-Tests-Core/RBCommentNodeVisitorTest.class.st
+++ b/src/AST-Tests-Core/RBCommentNodeVisitorTest.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : #RBCommentNodeVisitorTest,
+	#superclass : #TestCase,
+	#category : #'AST-Tests-Core'
+}
+
+{ #category : #tests }
+RBCommentNodeVisitorTest >> testVisitDetect [
+	| node tree |
+	tree := RBParser parseExpression: '
+	"comment 1"
+	"comment 2"
+	"comment 3"
+	^true'.
+	
+	node := RBCommentNodeVisitor visit: tree detect: [ :n | n intersectsInterval: (20 to: 20) ].
+	
+	self 
+		assert: node contents equals: 'comment 2'
+]
+
+{ #category : #tests }
+RBCommentNodeVisitorTest >> testVisitDo [
+	| node tree count |
+	tree := RBParser parseExpression: '
+	"comment 1"
+	"comment 2"
+	"comment 3"
+	^true'.
+	
+	count := 0.
+	node := RBCommentNodeVisitor visit: tree do: [ :n | count := count + 1 ].
+	
+	self 
+		assert: count equals: 3
+]
+
+{ #category : #tests }
+RBCommentNodeVisitorTest >> testVisitSelect [
+	| node tree |
+	tree := RBParser parseExpression: '
+	"comment 1"
+	"comment 2"
+	"comment 3"
+	^true'.
+	
+	node := RBCommentNodeVisitor visit: tree select: [ :n | n contents endsWith: '2'].
+	
+	self 
+		assert: node first contents equals: 'comment 2'
+]

--- a/src/AST-Tests-Core/RBCommentTest.class.st
+++ b/src/AST-Tests-Core/RBCommentTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #RBCommentTest,
+	#superclass : #TestCase,
+	#category : #'AST-Tests-Core'
+}
+
+{ #category : #tests }
+RBCommentTest >> testIntersectsInterval [
+	| node |
+	node:= RBComment with: 'Some sample text' at: 5.
+	
+	self 
+		assert: (node intersectsInterval: (4 to: 6)) description: 'either side of interval';
+		assert: (node intersectsInterval: (4 to: 5)) description: 'before and on interval';
+		assert: (node intersectsInterval: (5 to: 6)) description: 'and and after interval';
+		assert: (node intersectsInterval: (5 to: 5)) description: 'on interval interval';
+		assert: (node intersectsInterval: (1 to: 4)) not description: 'not in interval'
+]

--- a/src/AST-Tests-Core/RBParserTest.class.st
+++ b/src/AST-Tests-Core/RBParserTest.class.st
@@ -26,10 +26,17 @@ RBParserTest >> exampleClasses [
 
 { #category : #private }
 RBParserTest >> parseError: each [
-	RBParser 
-		parseExpression: each first 
-		onError: [ :string :pos | ^ self assert: pos equals: each last ].
+	
+	self parseError: each first onError: [ :string :pos | ^ self assert: pos equals: each last ].
 	self assert: false description: 'Parser didn''t fail'
+	
+]
+
+{ #category : #private }
+RBParserTest >> parseError: expression onError: aBlock [
+	^RBParser 
+		parseExpression: expression 
+		onError: aBlock
 ]
 
 { #category : #private }
@@ -582,6 +589,21 @@ indicate the invalid expression."
 RBParserTest >> testParserErrors [
 	#(#('self foo. + 3' 11) #('#(' 3) #('self 0' 6) #('self asdf;;asfd' 11)) 
 		do: [:each | self parseError: each]
+]
+
+{ #category : #'tests parsing' }
+RBParserTest >> testParserErrorsWithErrorBlock [
+	"Parse source with errors and ensure we identify them"
+	
+	#(#('self foo. + 3' 2) #('#(' 1) #('self 0' 1) #('self asdf;;asfd' 2)) 
+		do: [:each | |ast errorCount|
+			   [ ast := self parseError: each first onError: 
+					[:msg :pos :parser | parser step. parser parseErrorNode: msg]] 
+						on: ReparseAfterSourceEditing do: [].
+						
+				errorCount := 0.
+				RBParseErrorNodeVisitor visit: ast do: [ :n | errorCount := errorCount + 1 ].
+				self assert: errorCount equals: each last ]
 ]
 
 { #category : #'tests parsing' }

--- a/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
+++ b/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
@@ -1,0 +1,477 @@
+"
+A RubSmalltalkEditorTest is a test class for testing the behavior of RubSmalltalkEditor
+"
+Class {
+	#name : #RubSmalltalkEditorTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'source',
+		'selection'
+	],
+	#category : #'Rubric-Tests'
+}
+
+{ #category : #assertions }
+RubSmalltalkEditorTest >> assertNodeError [
+	| result |
+	result := RubSmalltalkEditor new
+		bestNodeInString: self source
+		at: self selection
+		edittingMode: RubSmalltalkCodeMode new
+		shouldFavourExpressions: true
+		onError: [ ^ true ].
+
+	self
+		assert: false
+		description: 'Should have got an error not: ' , result printString
+]
+
+{ #category : #assertions }
+RubSmalltalkEditorTest >> assertNodeSelector: aSelector [
+	| node |
+	
+	node := self exectuteBestNodeFor: aSelector.
+
+	self assert: node selector equals: aSelector
+]
+
+{ #category : #assertions }
+RubSmalltalkEditorTest >> assertNodeSelector: aSelector description: aString [
+	self assertNodeSelector: aSelector
+]
+
+{ #category : #assertions }
+RubSmalltalkEditorTest >> assertNodeValue: anObject [
+	| node |
+	
+	node := self exectuteBestNodeFor: anObject printString.
+
+	self assert: node value equals: anObject 
+]
+
+{ #category : #assertions }
+RubSmalltalkEditorTest >> assertNodeValue: anObject description: aString [
+	self assertNodeValue: anObject 
+]
+
+{ #category : #assertions }
+RubSmalltalkEditorTest >> assertNodeVariable: anObject [
+	| node |
+	
+	node := self exectuteBestNodeFor: anObject printString.
+
+	self assert: node name equals: anObject 
+]
+
+{ #category : #assertions }
+RubSmalltalkEditorTest >> assertPlaygroundNodeSelector: aSelector [
+	| node |
+	
+	node := self exectuteBestPlaygroundNodeFor: aSelector.
+
+	self assert: node selector equals: aSelector
+]
+
+{ #category : #assertions }
+RubSmalltalkEditorTest >> assertPlaygroundNodeValue: anObject [
+	| node |
+	
+	node := self exectuteBestPlaygroundNodeFor: anObject printString.
+
+	self assert: node value printString equals: (anObject isString ifTrue: [anObject ] ifFalse: [anObject printString])
+]
+
+{ #category : #helpers }
+RubSmalltalkEditorTest >> exectuteBestNodeFor: aSelector [
+	^ self exectuteBestNodeFor: aSelector edittingMode: RubSmalltalkCodeMode new
+]
+
+{ #category : #helpers }
+RubSmalltalkEditorTest >> exectuteBestNodeFor: aSelector edittingMode: aRubEdittingMode [
+	^ RubSmalltalkEditor new
+		bestNodeInString: self source
+		at: self selection
+		edittingMode: aRubEdittingMode
+		shouldFavourExpressions: true
+		onError: [ self assert: false description: 'node not found for: ' , aSelector ]
+]
+
+{ #category : #helpers }
+RubSmalltalkEditorTest >> exectuteBestPlaygroundNodeFor: aSelector [
+	^ self exectuteBestNodeFor: aSelector edittingMode: RubSmalltalkScriptingMode new
+]
+
+{ #category : #helpers }
+RubSmalltalkEditorTest >> positionAfter: aString [
+	| pos |
+	
+	pos := (self source findString: aString) + aString size.
+	self selection: (pos to: pos).
+	
+]
+
+{ #category : #helpers }
+RubSmalltalkEditorTest >> positionBefore: aString [
+	self positionBefore: aString offset: 0
+	
+]
+
+{ #category : #helpers }
+RubSmalltalkEditorTest >> positionBefore: aString offset: aNumber [
+	| pos |
+	
+	pos := (self source findString: aString) + aNumber.
+	self selection: (pos to: pos).
+	
+]
+
+{ #category : #helpers }
+RubSmalltalkEditorTest >> positionOn: aString [
+	| pos |
+	
+	pos := (self source findString: aString).
+	self selection: (pos to: pos + aString size).
+	
+]
+
+{ #category : #accessing }
+RubSmalltalkEditorTest >> selection [
+	^ selection
+]
+
+{ #category : #accessing }
+RubSmalltalkEditorTest >> selection: anObject [
+	selection := anObject
+]
+
+{ #category : #accessing }
+RubSmalltalkEditorTest >> source [
+	^ source
+]
+
+{ #category : #accessing }
+RubSmalltalkEditorTest >> source: anObject [
+	source := anObject
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithInvalidEmptySource [
+	
+	self source: ''.
+	
+	self 
+		positionAfter: '';
+		assertNodeError.
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithInvalidMethodIncompleteMidSourceNearNextMessage [
+	
+	self source: 'testMethod
+	self msg1.
+		
+	1 + 300
+	
+	^self'.
+	
+	self 
+		positionBefore: '^self' offset: -1;
+		assertNodeValue: 300.
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithInvalidMethodIncompleteMidSourceNearPreviousMessage [
+	
+	self source: 'testMethod
+	self msg1.
+		
+	1 + 300
+	^self'.
+	
+	self 
+		positionBefore: '1 +' offset: -2;
+		assertNodeSelector: #msg1 description: 'should backup to closest node unaffected by error'.
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithInvalidMethodIncompleteMidSourceOnLineEnd [
+	
+	self source: 'testMethod
+	self msg1.
+		
+	1 + 300
+	^self'.
+	
+	self 
+		positionAfter: '300';
+		assertNodeValue: 300 description: 'should let you select a value you have just typed (e.g. to widen and bracket)'
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithInvalidMethodIncompleteMidSourceOnMessage [
+	
+	self source: 'testMethod
+	self msg1.
+		
+	1 + 300
+	^self'.
+	
+	self 
+		positionAfter: '+';
+		assertNodeSelector: #+ description: 'should let you select an operator for implementorsOf etc.'.
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithInvalidMethodOnValidStatementBelowError [
+	
+	self source: 'testMethod
+	self msg1.
+		
+	1 #broken
+	
+	self msg2.
+	^self'.
+	
+	self 
+		positionAfter: 'msg2';
+		assertNodeSelector: #msg2 description: 'should let you select a valid selector in valid code after the error'
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithInvalidPlaygroundIncompleteMidSource [
+	
+	self source: '
+	self msg1.
+		
+	1 + 300
+	^self'.
+	
+	self 
+		positionAfter: '300';
+		assertNodeValue: 300.
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithInvalidPlaygroundIncompleteMidSourceThenBrackets [
+	
+	self source: '
+	self msg1.
+		
+	1 + 300
+	(String new)'.
+	
+	self 
+		positionAfter: 'String';
+		assertNodeVariable: #String
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithInvalidPlaygroundParsableError [
+	
+	self source: 'fallbackBlock := [^self].
+	node := self bestNodeInTextAreaOnError: fallbackBlock.
+	
+	node isMethod ifFalse: [ 
+		node isValue and: [  node isSymbol ]
+		[ node isMessage ] whileFalse: [ 
+	 		(node := node parent) ifNil: fallbackBlock ]].'.
+	
+	self 
+		positionAfter: 'isSymbol ]';
+		assertPlaygroundNodeValue: 'RBBlockNode([ node isSymbol ])'.
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithInvalidPlaygroundUnParsableError [
+	
+	self source: 'fallbackBlock := [^self].
+	node := self bestNodeInTextAreaOnError: fallbackBlock.
+	
+	node isMethod ifFalse: [ 
+		node isValue and: [  node isSymbol ]
+		[ node isMessage ] whileFalse: [ false ]].'.
+	
+	self 
+		positionAfter: 'isMessage ]';
+		assertPlaygroundNodeValue: 'RBBlockNode([ node isMessage ])'.
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidBinaryOperation [
+	
+	self source: 'testMethod
+	5 + 100'.
+	
+	self 
+		positionAfter: '+';
+		assertNodeSelector: #+.
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidCascadeLastStatement [
+
+	self source: 'testMethod
+	^self
+		msg1;
+		msg2;
+		msg3'.
+	
+	self 
+		positionAfter: 'msg3';
+		assertNodeSelector: #msg3
+	
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidCascadeMidStatement [
+
+	self source: 'testMethod
+	^self
+		msg1;
+		msg2;
+		msg3'.
+	
+	self 
+		positionAfter: 'msg2;';
+		assertNodeSelector: #msg2
+	
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidKeywordMessage [
+	
+	self source: 'testMethod
+	1 to: 20 do: []'.
+	
+	self 
+		positionAfter: 'to';
+		assertNodeSelector: #to:do:
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidPlayground [
+	self source: '5 + 100'.
+	
+	self 
+		positionAfter: '100';
+		assertPlaygroundNodeValue: 100
+	
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidPlaygroundSimpleMsg [
+	self source: 'self msg1
+	'.
+	
+	self 
+		positionAfter: 'msg1';
+		assertPlaygroundNodeSelector: #msg1
+	
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidPostionOnMethodEnd [
+	
+	self source: 'testMethod
+	5 + 9'.
+	
+	self 
+		positionAfter: '9';
+		assertNodeValue: 9
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidPostionOnMethodPeriodEnd [
+
+	self source: 'testMethod
+	2 / 3.
+	^5 + 9.'.
+	
+	self 
+		positionAfter: '9.';
+		assertNodeValue: 9
+		
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidPostionOnReturningMethodEnd [
+
+	self source: 'testMethod
+	^5 + 9'.
+	
+	self 
+		positionAfter: '9';
+		assertNodeValue: 9
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidPostionOnStatementPeriodEnd [
+
+	self source: 'testMethod
+	2 / 3.
+	^5 + 9.'.
+	
+	self 
+		positionAfter: '3.';
+		assertNodeValue: 3
+	
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidSelectorMidSource [
+
+	self source: 'testMethod
+	5 + 3.
+	7 / 8'.
+	
+	self 
+		positionAfter: '+';
+		assertNodeSelector: #+
+		
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidSimpleMethod [
+
+	self source: 'testMethod
+	^5 + 100
+	'.
+	
+	self 
+		positionAfter: '100';
+		assertNodeValue: 100
+	
+
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testBestNodeWithValidValueMidSource [
+
+	self source: 'testMethod
+	5 + 3.
+	7 / 8'.
+	
+	self 
+		positionAfter: '3';
+		assertNodeValue: 3
+
+]

--- a/src/Rubric/RubAbstractSmalltalkMode.class.st
+++ b/src/Rubric/RubAbstractSmalltalkMode.class.st
@@ -17,3 +17,20 @@ RubAbstractSmalltalkMode >> editorClass [
 RubAbstractSmalltalkMode >> isCodeCompletionAllowed [
 	^ true
 ]
+
+{ #category : #'as yet unclassified' }
+RubAbstractSmalltalkMode >> isScripting [
+	^ false
+]
+
+{ #category : #parsing }
+RubAbstractSmalltalkMode >> parseExpression: aString [
+
+	self subclassResponsibility
+]
+
+{ #category : #parsing }
+RubAbstractSmalltalkMode >> parseSource: aString [
+
+	self subclassResponsibility
+]

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -163,6 +163,18 @@ RubSmalltalkCodeMode >> maxFormatterLineLength [
 		ifFalse: [ 70 ]
 ]
 
+{ #category : #parsing }
+RubSmalltalkCodeMode >> parseExpression: aString [
+
+	^RBParser parseFaultyExpression: aString
+]
+
+{ #category : #parsing }
+RubSmalltalkCodeMode >> parseSource: aString [
+
+	^RBParser parseFaultyMethod: aString
+]
+
 { #category : #shout }
 RubSmalltalkCodeMode >> shoutAboutToStyle: myShoutStyler [
 	^ self model isNil

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -125,6 +125,51 @@ RubSmalltalkEditor >> basicInspectIt [
 ]
 
 { #category : #'menu messages' }
+RubSmalltalkEditor >> bestNodeInString: source at: selectionInterval edittingMode: aRubEdittingMode shouldFavourExpressions: isFavouringExpressions onError: aBlock [
+	"Find the best node in the source text in the identified selection area"
+	
+	| ast node start stop |
+
+	start := selectionInterval first min: source size.
+	stop := selectionInterval last min: source size.
+	
+	ast := aRubEdittingMode parseSource: source.
+	
+	ast ifNotNil: [ 
+		"If there is no text selection"
+		((selectionInterval size < 2) and: [ isFavouringExpressions ]) ifTrue: [ 
+			"If there is white space or statement terminator, try to backup to find a better node"		
+			[stop > 0 and: [('.;' includes: (source at: stop)) or: [(source at: stop) isSeparator ]]]
+				whileTrue: [ start := stop := stop - 1 ]].
+		
+		node := ast bestNodeFor: (start to: stop).
+		
+		node ifNil: [ 
+			node := RBParseErrorNodeVisitor
+				visit: ast 
+				detect: [ :n | n intersectsInterval: (start to: start)]
+				ifNone: [ ^aBlock value ]].
+		
+		node isFaulty ifTrue: [ 
+			node allChildren size = 1 ifTrue: [ 
+				(aRubEdittingMode parseExpression: (node value padLeftTo: source size)) 
+					ifNil: [ ^node ] 
+					ifNotNil: [ :newNode |
+						ast replaceNode: node withNode: newNode.
+						node := newNode ].
+				].
+			
+			node := RBGenericNodeVisitor 
+				visit: node 
+				detect: [ :n | n intersectsInterval: (start to: start) ] 
+				ifNone: [ node ] ] ].
+	
+
+	^node
+
+]
+
+{ #category : #'menu messages' }
 RubSmalltalkEditor >> bestNodeInTextArea [
 	"Find the best node in the editor text area at the current pointer location"
 	
@@ -139,6 +184,24 @@ RubSmalltalkEditor >> bestNodeInTextArea [
 	
 	^node bestNodeFor: (start to: stop).
 	
+]
+
+{ #category : #'menu messages' }
+RubSmalltalkEditor >> bestNodeInTextAreaOnError: aBlock [
+	"Find the best node in the editor text area at the current pointer location"
+
+	| start stop source |
+	start := self textArea startIndex.
+	stop := self textArea stopIndex.
+
+	source := self textArea string.
+
+	^ self
+		bestNodeInString: source
+		at: (start to: stop)
+		edittingMode: self textArea editingMode
+		shouldFavourExpressions: true
+		onError: aBlock
 ]
 
 { #category : #binding }
@@ -431,27 +494,23 @@ RubSmalltalkEditor >> exploreIt: aKeyboardEvent [
 RubSmalltalkEditor >> findClassFromAST [
 	"Try to make a class name out of the current text selection"
 
-	| node className |		
+	| node fallbackBlock className |		
 	
 	"Preserve original behavior - although could consider building AST from selection"
 	self hasSelection ifTrue: [ 
 		^(self selection string copyWithoutAll: CharacterSet crlf) trimBoth ].
 	
-	node := self bestNodeInTextArea.
-	
-	node ifNil: [ 
-		self selectLine.
-		^ self hasSelection 
-			ifTrue: [ (self selection string copyWithoutAll: CharacterSet crlf) trimBoth ]
-			ifFalse: [ nil ] ].
+	fallbackBlock := [^nil].
+
+	node := self bestNodeInTextAreaOnError: fallbackBlock.
 	
 	[node isVariable] whileFalse: [ 
-	 	(node := node parent) ifNil: [^nil]. ].
+	 	(node := node parent) ifNil: fallbackBlock ].
 	
 	className := node name.
 	
 	[ className first isUppercase ] whileFalse: [ 
-		(className := className allButFirst) ifEmpty: [^nil].  ].
+		(className := className allButFirst) ifEmpty: fallbackBlock  ].
 	
 	^className
 ]
@@ -460,15 +519,18 @@ RubSmalltalkEditor >> findClassFromAST [
 RubSmalltalkEditor >> findSelectorFromAST [
 	"Try to make a selector out of the current text selection"
 
-	| node |
-	node := self bestNodeInTextArea.
-	(node isNil or: [node isSequence]) ifTrue: [
-		self selectLine.
-		^ RBParser parseFaultyExpression: self selection string.]. 
+	| node fallbackBlock |
+
+	fallbackBlock := [^self].
+	node := self bestNodeInTextAreaOnError: fallbackBlock.
+	
 	node isMethod ifFalse: [ 
+		(node isValue and: [ node value isSymbol ]) ifTrue: [ ^node value ].
+				
 		[ node isMessage ] whileFalse: [ 
-	 		(node := node parent) ]].
-	^node 
+	 		(node := node parent) ifNil: fallbackBlock ]].
+	
+	^node selector
 ]
 
 { #category : #private }
@@ -506,9 +568,9 @@ RubSmalltalkEditor >> implementorsOfIt [
 	"Open an implementors browser on the selected selector"
 
 	| aSelector |
+	"self lineSelectAndEmptyCheck: [^ self]."
 	(aSelector := self selectedSelector) ifNil: [^ textArea flash].
 	self implementorsOf: aSelector
-
 ]
 
 { #category : #'editing keys' }
@@ -688,6 +750,38 @@ RubSmalltalkEditor >> notify: aString at: anInteger in: aStream [
 
 ]
 
+{ #category : #parsing }
+RubSmalltalkEditor >> parseOptimistically: source withCursorAt: loc [
+	"Find the best node in the editor text area at the current pointer location"
+	
+	| ast |
+
+	ast := [ RBParser parseMethod: source onError: [ :msg :pos :parser | | seqNode errorNode |
+		
+		errorNode := RBParseErrorNode
+			errorMessage: msg value: parser currentToken value printString at: pos. 
+			
+		seqNode := parser sequenceNodeClass new.
+		parser 
+			step; 
+			parseStatements: true into: seqNode.
+			
+		seqNode 
+			addNodeFirst: errorNode;
+			yourself
+			
+		]] onDNU: #body: do: [ nil "allow source fragment handling"].
+
+	(ast notNil and: [ ast isMethod and: [ast selector ~= #self]]) ifTrue: [ ^ast ].
+		
+	^[ RBParser parseExpression: source onError: [ :msg :pos :parser |
+			"^self parseOptimisticallyRetrying: source withErrorAt: pos1 withCursorAt: loc]]."
+			parser step; parseErrorNode: msg ]] on: ReparseAfterSourceEditing do: ["prevent correction tool popup"].
+	
+	
+
+]
+
 { #category : #'editing keys' }
 RubSmalltalkEditor >> pasteInitials: aKeyboardEvent [ 
 	"Replace the current text selection by an authorship name/date stamp; invoked by cmd-shift-v, easy way to put an authorship stamp in the comments of an editor."
@@ -750,9 +844,9 @@ RubSmalltalkEditor >> referencesToIt [
 	"Open a references browser on the selected symbol"
 
 	| aSymbol |
-	self selectLine.
-	(aSymbol := self selectedSymbol) isNil
-		ifTrue: [ ^ textArea flash ].
+	"self selectLine."
+	(aSymbol := self selectedSymbol) ifNil: [^ textArea flash].
+
 	self referencesTo: aSymbol
 ]
 
@@ -793,10 +887,10 @@ RubSmalltalkEditor >> selectedSelector [
 
 	| node |
 	
-	node := self hasSelection 
-		ifTrue: [ RBParser parseFaultyExpression: self selection string. ]
-		ifFalse: [ self findSelectorFromAST ].
-	node nodesDo: [ :n | 
+	self hasSelection ifFalse: [ ^self findSelectorFromAST ].
+	node := RBParser parseFaultyExpression: self selection string.
+	node
+		nodesDo: [ :n | 
 			n isMessage
 				ifTrue: [ ^ n selector ].
 			n isVariable
@@ -812,11 +906,11 @@ RubSmalltalkEditor >> selectedSymbol [
 	"Return the currently selected symbol, or nil if none.  Spaces, tabs and returns are ignored"
 
 	| aString |
-	self hasCursor ifTrue: [^ nil].
+	self hasCursor ifTrue: [^self findSelectorFromAST].
 	aString := self selection string copyWithoutAll:
 		{Character space.  Character cr.  Character tab}.
-	aString isEmpty ifTrue: [^ nil].
-	Symbol hasInterned: aString  ifTrue: [:sym | ^ sym].
+	aString size = 0 ifTrue: [^ nil].
+	Symbol hasInterned: aString ifTrue: [:sym | ^sym].
 
 	^ nil
 ]
@@ -966,9 +1060,7 @@ RubSmalltalkEditor >> sendersOfIt [
 
 	| selectedSelector syst |
 	"self lineSelectAndEmptyCheck: [ ^ self ]."
-	selectedSelector := self selectedSelector.
-	selectedSelector isNil
-		ifTrue: [ ^ textArea flash ].
+	(selectedSelector := self selectedSelector) ifNil: [ ^ textArea flash ].
 	syst := self model interactionModel systemNavigation.
 	syst browseAllSendersOrUsersOf: selectedSelector
 ]

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -750,38 +750,6 @@ RubSmalltalkEditor >> notify: aString at: anInteger in: aStream [
 
 ]
 
-{ #category : #parsing }
-RubSmalltalkEditor >> parseOptimistically: source withCursorAt: loc [
-	"Find the best node in the editor text area at the current pointer location"
-	
-	| ast |
-
-	ast := [ RBParser parseMethod: source onError: [ :msg :pos :parser | | seqNode errorNode |
-		
-		errorNode := RBParseErrorNode
-			errorMessage: msg value: parser currentToken value printString at: pos. 
-			
-		seqNode := parser sequenceNodeClass new.
-		parser 
-			step; 
-			parseStatements: true into: seqNode.
-			
-		seqNode 
-			addNodeFirst: errorNode;
-			yourself
-			
-		]] onDNU: #body: do: [ nil "allow source fragment handling"].
-
-	(ast notNil and: [ ast isMethod and: [ast selector ~= #self]]) ifTrue: [ ^ast ].
-		
-	^[ RBParser parseExpression: source onError: [ :msg :pos :parser |
-			"^self parseOptimisticallyRetrying: source withErrorAt: pos1 withCursorAt: loc]]."
-			parser step; parseErrorNode: msg ]] on: ReparseAfterSourceEditing do: ["prevent correction tool popup"].
-	
-	
-
-]
-
 { #category : #'editing keys' }
 RubSmalltalkEditor >> pasteInitials: aKeyboardEvent [ 
 	"Replace the current text selection by an authorship name/date stamp; invoked by cmd-shift-v, easy way to put an authorship stamp in the comments of an editor."

--- a/src/Rubric/RubSmalltalkScriptingMode.class.st
+++ b/src/Rubric/RubSmalltalkScriptingMode.class.st
@@ -23,6 +23,17 @@ RubSmalltalkScriptingMode class >> label [
 ]
 
 { #category : #'initialize-release' }
+RubSmalltalkScriptingMode >> isScripting [
+	^ true
+]
+
+{ #category : #parsing }
+RubSmalltalkScriptingMode >> parseSource: aString [
+
+	^RBParser parseFaultyExpression: aString
+]
+
+{ #category : #'initialize-release' }
 RubSmalltalkScriptingMode >> updateTextAreaWhenPlugged [
 	super updateTextAreaWhenPlugged.
 	self textArea shoutStyler beForSmalltalkScripting


### PR DESCRIPTION
Improves how the senders/implementers functions work. NOTE: in a Pharo7 image more additional changes are needed for Calypso to make use of the methods introduced here (however there is a chicken and egg in the current process due to project dependencies).
